### PR TITLE
chore: update CODEOWNERS (use team)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Mistat @jackchuka @ikawaha @dragon3
+* @tailor-inc/maintainers-gqlcheck


### PR DESCRIPTION
## WHAT

This pull request updates `CODEOWNERS` to use team instead of individual.
