### PR TITLE
chore: Update support go version from 1.21.5 to 1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tailor-inc/gqlcheck
 
-go 1.21.5
+go 1.23.0
 
 require (
 	github.com/ikawaha/httpcheck v1.12.4


### PR DESCRIPTION
This PR updates the Go version specified in go.mod from 1.21.5 to 1.23.0.
