### PR TITLE
feat: support query via GET

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ PASS
 
 gqlcheck also supports GET requests for GraphQL queries, following the [GraphQL over HTTP specification](https://graphql.github.io/graphql-over-http/).
 
+Use `TestWithMethod` to specify the HTTP method:
+
 ```go
 func TestServerViaGet(t *testing.T) {
 	h := handler.New(
@@ -62,8 +64,8 @@ func TestServerViaGet(t *testing.T) {
 	h.AddTransport(transport.GET{})
 
 	checker := gqlcheck.New(h, gqlcheck.Debug())
-	checker.Test(t).
-		QueryViaGet(`query {todos {text}}`).
+	checker.TestWithMethod(t, http.MethodGet).
+		Query(`query {todos {text}}`).
 		Check().
 		HasStatusOK().
 		HasNoErrors().
@@ -85,11 +87,11 @@ OUTPUT:
 PASS
 ```
 
-You can also pass variables using `QueryViaGetWithVariables()`:
+You can also pass variables using `QueryWithVariables()`:
 
 ```go
-checker.Test(t).
-	QueryViaGetWithVariables(
+checker.TestWithMethod(t, http.MethodGet).
+	QueryWithVariables(
 		`query GetUser($id: ID!) { user(id: $id) { name } }`,
 		map[string]any{"id": "123"},
 	).

--- a/testdata/gqlgen-todos/server_test.go
+++ b/testdata/gqlgen-todos/server_test.go
@@ -30,3 +30,58 @@ func TestServer(t *testing.T) {
 			"todos": []any{},
 		})
 }
+
+func TestServerViaGet(t *testing.T) {
+	h := handler.New(
+		graph.NewExecutableSchema(
+			graph.Config{
+				Resolvers: &graph.Resolver{},
+			},
+		),
+	)
+	h.AddTransport(transport.GET{})
+
+	checker := gqlcheck.New(h, gqlcheck.Debug())
+	checker.Test(t).
+		QueryViaGet(`query {todos {text}}`).
+		Check().
+		HasStatusOK().
+		HasNoErrors().
+		HasData(map[string]any{
+			"todos": []any{},
+		})
+}
+
+func TestServerViaGetWithVariables(t *testing.T) {
+	h := handler.New(
+		graph.NewExecutableSchema(
+			graph.Config{
+				Resolvers: &graph.Resolver{},
+			},
+		),
+	)
+	h.AddTransport(transport.GET{})
+	h.AddTransport(transport.POST{})
+
+	checker := gqlcheck.New(h, gqlcheck.Debug())
+
+	// Create a todo via POST mutation with variables
+	checker.Test(t).
+		QueryWithVariables(
+			`mutation CreateTodo($input: NewTodo!) { createTodo(input: $input) { id text } }`,
+			map[string]any{"input": map[string]any{"text": "test todo", "userId": "user1"}},
+		).
+		Check().
+		HasStatusOK().
+		HasNoErrors()
+
+	// Query via GET (variables passed to demonstrate the feature)
+	checker.Test(t).
+		QueryViaGetWithVariables(
+			`query { todos { text } }`,
+			map[string]any{},
+		).
+		Check().
+		HasStatusOK().
+		HasNoErrors()
+}

--- a/testdata/gqlgen-todos/server_test.go
+++ b/testdata/gqlgen-todos/server_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/99designs/gqlgen/graphql/handler"
@@ -42,8 +43,8 @@ func TestServerViaGet(t *testing.T) {
 	h.AddTransport(transport.GET{})
 
 	checker := gqlcheck.New(h, gqlcheck.Debug())
-	checker.Test(t).
-		QueryViaGet(`query {todos {text}}`).
+	checker.TestWithMethod(t, http.MethodGet).
+		Query(`query {todos {text}}`).
 		Check().
 		HasStatusOK().
 		HasNoErrors().
@@ -76,8 +77,8 @@ func TestServerViaGetWithVariables(t *testing.T) {
 		HasNoErrors()
 
 	// Query via GET (variables passed to demonstrate the feature)
-	checker.Test(t).
-		QueryViaGetWithVariables(
+	checker.TestWithMethod(t, http.MethodGet).
+		QueryWithVariables(
 			`query { todos { text } }`,
 			map[string]any{},
 		).

--- a/tester.go
+++ b/tester.go
@@ -29,11 +29,22 @@ type Tester struct {
 }
 
 // Test starts a new test with the given *testing.T.
+// The default HTTP method is POST.
 func (c *Checker) Test(t TestingT) *Tester {
 	return &Tester{
 		checker: c,
 		t:       t,
 		method:  http.MethodPost, // default
+		headers: make(map[string]string),
+	}
+}
+
+// TestWithMethod starts a new test with the given *testing.T and HTTP method.
+func (c *Checker) TestWithMethod(t TestingT, method string) *Tester {
+	return &Tester{
+		checker: c,
+		t:       t,
+		method:  method,
 		headers: make(map[string]string),
 	}
 }

--- a/tester.go
+++ b/tester.go
@@ -1,7 +1,9 @@
 package gqlcheck
 
 import (
+	"encoding/json"
 	"net/http"
+	"net/url"
 
 	"github.com/ikawaha/httpcheck"
 )
@@ -14,19 +16,59 @@ type TestingT interface {
 
 // Tester represents the GraphQL tester.
 type Tester struct {
+	// For building request (before Check)
+	checker   *Checker
+	t         TestingT
+	method    string
+	headers   map[string]string
+	query     string
+	variables map[string]any
+
+	// For response assertions (after Check)
 	client *httpcheck.Tester
 }
 
 // Test starts a new test with the given *testing.T.
 func (c *Checker) Test(t TestingT) *Tester {
 	return &Tester{
-		client: c.client.Test(t, http.MethodPost, "").
-			WithHeader("Content-Type", "application/graphql"),
+		checker: c,
+		t:       t,
+		method:  http.MethodPost, // default
+		headers: make(map[string]string),
 	}
 }
 
 // Check makes request to built request object.
 // After request is made, it saves response object for future assertions.
 func (tt *Tester) Check() *Tester {
-	return &Tester{client: tt.client.Check()}
+	var client *httpcheck.Tester
+
+	switch tt.method {
+	case http.MethodGet:
+		// GET: query parameters in URL
+		params := url.Values{}
+		params.Set("query", tt.query)
+		if tt.variables != nil {
+			v, _ := json.Marshal(tt.variables)
+			params.Set("variables", string(v))
+		}
+		path := "?" + params.Encode()
+		client = tt.checker.client.Test(tt.t, http.MethodGet, path)
+	default:
+		// POST: JSON body
+		client = tt.checker.client.Test(tt.t, http.MethodPost, "").
+			WithHeader("Content-Type", "application/json")
+		body := map[string]any{"query": tt.query}
+		if tt.variables != nil {
+			body["variables"] = tt.variables
+		}
+		client = client.WithJSON(body)
+	}
+
+	// Apply headers
+	for k, v := range tt.headers {
+		client = client.WithHeader(k, v)
+	}
+
+	return &Tester{client: client.Check()}
 }

--- a/tester.go
+++ b/tester.go
@@ -49,7 +49,11 @@ func (tt *Tester) Check() *Tester {
 		params := url.Values{}
 		params.Set("query", tt.query)
 		if tt.variables != nil {
-			v, _ := json.Marshal(tt.variables)
+			v, err := json.Marshal(tt.variables)
+			if err != nil {
+				tt.t.Errorf("failed to marshal variables: %v", err)
+				tt.t.FailNow()
+			}
 			params.Set("variables", string(v))
 		}
 		path := "?" + params.Encode()

--- a/tester_auth.go
+++ b/tester_auth.go
@@ -1,11 +1,16 @@
 package gqlcheck
 
+import "encoding/base64"
+
 // WithBasicAuth is an alias to set basic auth in the request header.
 func (tt *Tester) WithBasicAuth(user, pass string) *Tester {
-	return &Tester{client: tt.client.WithBasicAuth(user, pass)}
+	auth := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+	tt.headers["Authorization"] = "Basic " + auth
+	return tt
 }
 
 // WithBearerAuth is an alias to set bearer auth in the request header.
 func (tt *Tester) WithBearerAuth(token string) *Tester {
-	return &Tester{client: tt.client.WithHeader("Authorization", "Bearer: "+token)}
+	tt.headers["Authorization"] = "Bearer " + token
+	return tt
 }

--- a/tester_header.go
+++ b/tester_header.go
@@ -2,10 +2,14 @@ package gqlcheck
 
 // WithHeader set header in the request.
 func (tt *Tester) WithHeader(key, value string) *Tester {
-	return &Tester{client: tt.client.WithHeader(key, value)}
+	tt.headers[key] = value
+	return tt
 }
 
 // WithHeaders sets header in the request.
 func (tt *Tester) WithHeaders(headers map[string]string) *Tester {
-	return &Tester{client: tt.client.WithHeaders(headers)}
+	for k, v := range headers {
+		tt.headers[k] = v
+	}
+	return tt
 }

--- a/tester_query.go
+++ b/tester_query.go
@@ -2,7 +2,6 @@ package gqlcheck
 
 import (
 	"encoding/json"
-	"net/http"
 )
 
 // Query is a struct to represent a query.
@@ -17,47 +16,21 @@ func (q Query) String() string {
 	return string(b)
 }
 
-// Request sets the query and variables to the request (POST).
+// Request sets the query and variables to the request.
 func (tt *Tester) Request(q Query) *Tester {
-	tt.method = http.MethodPost
 	tt.query = q.Query
 	tt.variables = q.Variables
 	return tt
 }
 
-// Query sets the query to the request (POST).
+// Query sets the query to the request.
 func (tt *Tester) Query(q string) *Tester {
-	tt.method = http.MethodPost
 	tt.query = q
 	return tt
 }
 
-// QueryWithVariables sets the query and variables to the request (POST).
+// QueryWithVariables sets the query and variables to the request.
 func (tt *Tester) QueryWithVariables(q string, variables map[string]any) *Tester {
-	tt.method = http.MethodPost
-	tt.query = q
-	tt.variables = variables
-	return tt
-}
-
-// RequestViaGet sets the query and variables to the request (GET).
-func (tt *Tester) RequestViaGet(q Query) *Tester {
-	tt.method = http.MethodGet
-	tt.query = q.Query
-	tt.variables = q.Variables
-	return tt
-}
-
-// QueryViaGet sets the query to the request (GET).
-func (tt *Tester) QueryViaGet(q string) *Tester {
-	tt.method = http.MethodGet
-	tt.query = q
-	return tt
-}
-
-// QueryViaGetWithVariables sets the query and variables to the request (GET).
-func (tt *Tester) QueryViaGetWithVariables(q string, variables map[string]any) *Tester {
-	tt.method = http.MethodGet
 	tt.query = q
 	tt.variables = variables
 	return tt

--- a/tester_query.go
+++ b/tester_query.go
@@ -2,6 +2,7 @@ package gqlcheck
 
 import (
 	"encoding/json"
+	"net/http"
 )
 
 // Query is a struct to represent a query.
@@ -16,25 +17,48 @@ func (q Query) String() string {
 	return string(b)
 }
 
-// Request sets the query and variables to the request.
+// Request sets the query and variables to the request (POST).
 func (tt *Tester) Request(q Query) *Tester {
-	return &Tester{client: tt.client.WithJSON(map[string]any{
-		"query":     q.Query,
-		"variables": q.Variables,
-	})}
+	tt.method = http.MethodPost
+	tt.query = q.Query
+	tt.variables = q.Variables
+	return tt
 }
 
-// Query sets the query to the request.
+// Query sets the query to the request (POST).
 func (tt *Tester) Query(q string) *Tester {
-	return &Tester{client: tt.client.WithJSON(map[string]any{
-		"query": q,
-	})}
+	tt.method = http.MethodPost
+	tt.query = q
+	return tt
 }
 
-// QueryWithVariables sets the query and variables to the request.
+// QueryWithVariables sets the query and variables to the request (POST).
 func (tt *Tester) QueryWithVariables(q string, variables map[string]any) *Tester {
-	return &Tester{client: tt.client.WithJSON(map[string]any{
-		"query":     q,
-		"variables": variables,
-	})}
+	tt.method = http.MethodPost
+	tt.query = q
+	tt.variables = variables
+	return tt
+}
+
+// RequestViaGet sets the query and variables to the request (GET).
+func (tt *Tester) RequestViaGet(q Query) *Tester {
+	tt.method = http.MethodGet
+	tt.query = q.Query
+	tt.variables = q.Variables
+	return tt
+}
+
+// QueryViaGet sets the query to the request (GET).
+func (tt *Tester) QueryViaGet(q string) *Tester {
+	tt.method = http.MethodGet
+	tt.query = q
+	return tt
+}
+
+// QueryViaGetWithVariables sets the query and variables to the request (GET).
+func (tt *Tester) QueryViaGetWithVariables(q string, variables map[string]any) *Tester {
+	tt.method = http.MethodGet
+	tt.query = q
+	tt.variables = variables
+	return tt
 }


### PR DESCRIPTION
## WHAT

Added support for GraphQL queries via GET requests, following the [GraphQL over HTTP specification](https://graphql.github.io/graphql-over-http/).

### New APIs

- `TestWithMethod(t TestingT, method string)` - Start a new test with a specified HTTP method

## WHY

The [GraphQL over HTTP specification](https://graphql.github.io/graphql-over-http/) supports the use of GET method for query operations.

GET requests for queries are useful in the following scenarios:

- Leveraging HTTP caching (CDN, browser cache, etc.)
- Bookmarkable query URLs
- Testing GraphQL servers that only enable GET transport

This PR enables gqlcheck to test GraphQL servers that use GET transport.