### PR TITLE
fix: setup ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,3 +22,7 @@ jobs:
       - name: Test
         run: |
           go test -v ./...
+      - name: Test
+        run: |
+          go test -v ./...
+        working-directory: testdata/gqlgen-todos

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-export GO111MODULE=on
-
 default: test
 
-ci: depsdev test
+test:
+	go test -v ./...
+	cd testdata/gqlgen-todos/ && go test -v ./...
 
 lint:
 	golangci-lint run ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tailor-platform/gqlcheck
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/ikawaha/httpcheck v1.12.5


### PR DESCRIPTION
## WHAT

- Update Go directive version from `1.23.0` to `1.24`
- Add tests for `testdata/gqlgen-todos` directory in CI workflow (`.github/workflows/go.yml`)
- Clean up Makefile

## WHY

- Go 1.24 is the current oldstable version, and this aligns with the go directive in `testdata/gqlgen-todos`
    - And allows easy installation of gocredits via `go install`
- The Go module under `testdata/gqlgen-todos` was not being tested in CI
- Simplify Makefile to ensure consistent test execution between local and CI environments

